### PR TITLE
Add package manager skeletons in C, C++, and Perl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Front
-A for-you package manager for Linux/BSD/TempleOS.
+
+A small cross-platform package manager base for Linux, BSD and TempleOS.
+
+## C example
+
+```c
+#include "package_manager.c"
+
+int main(void) {
+    printf("%s\n", detect_package_manager());
+    return 0;
+}
+```
+
+## C++ example
+
+```cpp
+#include "package_manager.cpp"
+int main() { return 0; }
+```
+
+## Perl example
+
+```perl
+require './package_manager.pl';
+```

--- a/front/package_manager.c
+++ b/front/package_manager.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+/* Simple package manager detector for C */
+
+const char *detect_package_manager(void) {
+#if defined(__linux__)
+    return "apt";
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    return "pkg";
+#elif defined(__TempleOS__)
+    return "unsupported";
+#else
+    return "unknown";
+#endif
+}
+
+int main(void) {
+    printf("Detected package manager: %s\n", detect_package_manager());
+    return 0;
+}

--- a/front/package_manager.cpp
+++ b/front/package_manager.cpp
@@ -1,0 +1,54 @@
+#include <iostream>
+#include <stdexcept>
+
+/* Simple package manager classes for C++ */
+
+class PackageManager {
+public:
+    virtual ~PackageManager() = default;
+    virtual const char* name() const = 0;
+};
+
+class AptManager : public PackageManager {
+public:
+    const char* name() const override { return "apt"; }
+};
+
+class PkgManager : public PackageManager {
+public:
+    const char* name() const override { return "pkg"; }
+};
+
+class TempleManager : public PackageManager {
+public:
+    const char* name() const override {
+        throw std::runtime_error("TempleOS is unsupported");
+    }
+};
+
+static PackageManager* detect() {
+#if defined(__linux__)
+    return new AptManager();
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    return new PkgManager();
+#elif defined(__TempleOS__)
+    return new TempleManager();
+#else
+    return nullptr;
+#endif
+}
+
+int main() {
+    PackageManager* pm = detect();
+    if (!pm) {
+        std::cout << "Unknown package manager\n";
+        return 0;
+    }
+    try {
+        std::cout << "Detected package manager: " << pm->name() << "\n";
+    } catch (const std::exception& e) {
+        std::cout << e.what() << "\n";
+    }
+    delete pm;
+    return 0;
+}

--- a/front/package_manager.pl
+++ b/front/package_manager.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+# Simple package manager detector for Perl
+
+sub detect_package_manager {
+    if ($^O eq 'linux') {
+        return 'apt';
+    } elsif ($^O =~ /bsd/) {
+        return 'pkg';
+    } elsif ($^O eq 'templeos') {
+        die "TempleOS is unsupported\n";
+    } else {
+        return 'unknown';
+    }
+}
+
+sub main {
+    my $pm = detect_package_manager();
+    print "Detected package manager: $pm\n";
+}
+
+main();


### PR DESCRIPTION
## Summary
- replace Python implementation with C, C++, and Perl examples
- document usage for the new language examples

## Testing
- `gcc -c front/package_manager.c && rm package_manager.o`
- `g++ -c front/package_manager.cpp && rm package_manager.o`
- `perl -c front/package_manager.pl`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b894ec3620832b8b539355b1c69bc4