### PR TITLE
Add package manager skeletons and CLI launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # Front
-A for-you package manager for Linux/BSD/TempleOS.
+
+A small cross-platform package manager base for Linux, BSD and TempleOS. Front is its own package manager and does not wrap other tools.
+
+## Usage
+
+Run the `front-pkg` launcher with sudo on Linux and BSD:
+
+```
+sudo front-pkg
+```
+
+On TempleOS, just invoke `front`:
+
+```
+front
+```
+
+## C example
+
+```c
+#include "package_manager.c"
+
+int main(void) {
+    printf("Front on %s\n", front_platform());
+    return 0;
+}
+```
+
+## C++ example
+
+```cpp
+#include "package_manager.cpp"
+
+int main() {
+    auto front = create();
+    if (front)
+        std::cout << "Front on " << front->platform() << "\n";
+    return 0;
+}
+```
+
+## Perl example
+
+```perl
+require './package_manager.pl';
+```

--- a/bin/front
+++ b/bin/front
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# Front package manager launcher for TempleOS
+set -e
+if [ "$(uname)" != "TempleOS" ]; then
+  echo "This Front launcher is intended for TempleOS" >&2
+  exit 1
+fi
+
+echo "Accessing Front on TempleOS"

--- a/bin/front-pkg
+++ b/bin/front-pkg
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Front package manager launcher for Unix-like systems
+set -e
+case "$(uname)" in
+  Linux)
+    echo "Accessing Front on Linux"
+    ;;
+  FreeBSD|NetBSD|OpenBSD)
+    echo "Accessing Front on BSD"
+    ;;
+  TempleOS)
+    echo "Use 'front' on TempleOS"
+    exit 1
+    ;;
+  *)
+    echo "Front is not supported on this platform" >&2
+    exit 1
+    ;;
+esac

--- a/front/package_manager.c
+++ b/front/package_manager.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+/* Simple Front package manager base for C */
+
+const char *front_platform(void) {
+#if defined(__linux__)
+    return "Linux";
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    return "BSD";
+#elif defined(__TempleOS__)
+    return "TempleOS";
+#else
+    return "Unknown";
+#endif
+}
+
+int main(void) {
+    printf("Front package manager on %s\n", front_platform());
+    return 0;
+}

--- a/front/package_manager.cpp
+++ b/front/package_manager.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <memory>
+
+/* Simple Front package manager classes for C++ */
+
+class Front {
+public:
+    virtual ~Front() = default;
+    virtual const char* platform() const = 0;
+};
+
+class FrontLinux : public Front {
+public:
+    const char* platform() const override { return "Linux"; }
+};
+
+class FrontBSD : public Front {
+public:
+    const char* platform() const override { return "BSD"; }
+};
+
+class FrontTempleOS : public Front {
+public:
+    const char* platform() const override { return "TempleOS"; }
+};
+
+static std::unique_ptr<Front> create() {
+#if defined(__linux__)
+    return std::unique_ptr<Front>(new FrontLinux());
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    return std::unique_ptr<Front>(new FrontBSD());
+#elif defined(__TempleOS__)
+    return std::unique_ptr<Front>(new FrontTempleOS());
+#else
+    return nullptr;
+#endif
+}
+
+int main() {
+    auto front = create();
+    if (!front) {
+        std::cout << "Front is unsupported on this platform\n";
+        return 0;
+    }
+    std::cout << "Front package manager on " << front->platform() << "\n";
+    return 0;
+}

--- a/front/package_manager.pl
+++ b/front/package_manager.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+# Simple Front package manager base for Perl
+
+sub front_platform {
+    if ($^O eq 'linux') {
+        return 'Linux';
+    } elsif ($^O =~ /bsd/) {
+        return 'BSD';
+    } elsif ($^O eq 'templeos') {
+        return 'TempleOS';
+    } else {
+        return 'Unknown';
+    }
+}
+
+sub main {
+    my $platform = front_platform();
+    print "Front package manager on $platform\n";
+}
+
+main();


### PR DESCRIPTION
## Summary
- treat Front as its own package manager rather than an apt/pkg frontend
- add OS-specific messages in the `front-pkg` launcher
- provide C, C++, and Perl skeletons that report the platform Front is running on
- document standalone behavior and example usage

## Testing
- `gcc -c front/package_manager.c && rm package_manager.o`
- `g++ -c front/package_manager.cpp && rm package_manager.o`
- `perl -c front/package_manager.pl`
- `bin/front-pkg`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b894ec3620832b8b539355b1c69bc4